### PR TITLE
building from source preparation (ubuntu)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -220,6 +220,7 @@ Building from source
     cd rbczmq
     git submodule init
     git submodule update
+    bundle install
     rake
 
 Running all tests
@@ -236,6 +237,13 @@ If you are installing the package on a new Mac ensure you have libtool and autoc
 You can get those with brew packaging system:
 
     brew install libtool autoconf automake
+    
+Ubuntu notes:
+
+If you are installing the package on a Ubuntu system ensure you have libtool installed. You will have to link the executable though.
+
+  sudo ln -s /usr/bin/libtoolize /usr/bin/libtool
+
 
 == LICENSE
 


### PR DESCRIPTION
rogera@core:~/code/gh.methodmissing.d/rbczmq$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 16.04.1 LTS
Release:        16.04
Codename:       xenial
rogera@core:~/code/gh.methodmissing.d/rbczmq$ ruby -v
ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-linux]
rogera@core:~/code/gh.methodmissing.d/rbczmq$
